### PR TITLE
chore: update pulumi preview workflow

### DIFF
--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -1,7 +1,7 @@
 name: Preview infrastructure
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [master, staging, dev]
   workflow_dispatch:
 


### PR DESCRIPTION
unsure why this is an issue now: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

and only the `GCP_SSH_PUBLIC_KEY` seems to be undefined, `CLOUDFLARE_API_TOKEN` is also a secret and that is coming through:

<img width="992" alt="image" src="https://github.com/user-attachments/assets/f5e85287-33ab-4e22-99a7-18238600daf1" />
