### PR TITLE
chore: update workflows to use var instead of secret for GCP_SSH_PUBLIC_KEY

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Install dependencies: infrastructure"
         run: go mod download
         working-directory: infrastructure
-        
+
       - name: "Deploy stack: skulpture/landing/prod"
         uses: pulumi/actions@v5
         with:
@@ -60,7 +60,7 @@ jobs:
           CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           GOOGLE_SERVICE_ACCOUNT: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
-          GCP_SSH_PUBLIC_KEY: ${{ secrets.GCP_SSH_PUBLIC_KEY }}
+          GCP_SSH_PUBLIC_KEY: ${{ vars.GCP_SSH_PUBLIC_KEY }}
 
   build:
     if: ${{ always() }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -91,7 +91,7 @@ jobs:
           tags: |
             skulpture/landing-api:${{ env.TAG }}
 
-  deploy:    
+  deploy:
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -59,4 +59,4 @@ jobs:
           CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           GOOGLE_SERVICE_ACCOUNT: ${{ vars.GOOGLE_SERVICE_ACCOUNT }}
-          GCP_SSH_PUBLIC_KEY: ${{ secrets.GCP_SSH_PUBLIC_KEY }}
+          GCP_SSH_PUBLIC_KEY: ${{ vars.GCP_SSH_PUBLIC_KEY }}


### PR DESCRIPTION
unsure why this is an issue now: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

previous runs which were fine:
- https://github.com/skulpturenz/skulpture.xyz/pull/325
- https://github.com/skulpturenz/skulpture.xyz/pull/326

and only the `GCP_SSH_PUBLIC_KEY` seems to be undefined, `CLOUDFLARE_API_TOKEN` is also a secret and that is coming through:

<img width="992" alt="image" src="https://github.com/user-attachments/assets/f5e85287-33ab-4e22-99a7-18238600daf1" />
