### PR TITLE
chore: specify WithInsecure option

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -430,7 +430,9 @@ func initOtel(ctx context.Context, r *chi.Mux) func(context.Context) error {
 	// TODO: json payload
 	exporter, err := otlptrace.New(
 		ctx,
-		otlptracehttp.NewClient(),
+		otlptracehttp.NewClient(
+			// see: https://www.parseable.com/docs/OpenTelemetry/traces
+			otlptracehttp.WithInsecure()),
 	)
 
 	if err != nil {
@@ -460,7 +462,9 @@ func initOtel(ctx context.Context, r *chi.Mux) func(context.Context) error {
 
 	logExporter, _ := otlplogs.NewExporter(ctx, otlplogs.WithClient(otlplogshttp.NewClient(
 		// parseable only supports json payloads
-		otlplogshttp.WithJsonProtocol())))
+		otlplogshttp.WithJsonProtocol(),
+		// see: https://www.parseable.com/docs/OpenTelemetry/logs
+		otlplogshttp.WithInsecure())))
 	loggerProvider := sdklog.NewLoggerProvider(
 		sdklog.WithBatcher(logExporter),
 		sdklog.WithResource(resources),


### PR DESCRIPTION
setting json on the log exporter seems to also have stopped the traces exporter from reporting content type errors:
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/ed115ad2-20a2-415d-bebb-1ff0714cfdaa" />
